### PR TITLE
Add optional document origin data to facturacion request

### DIFF
--- a/src/main/java/com/comerzzia/api/v2/facturacionmagento/services/facturacion/FacturacionService.java
+++ b/src/main/java/com/comerzzia/api/v2/facturacionmagento/services/facturacion/FacturacionService.java
@@ -59,6 +59,7 @@ import com.comerzzia.api.v2.facturacionmagento.services.usuarios.UsuariosService
 import com.comerzzia.api.v2.facturacionmagento.web.rest.facturacion.dtos.FacturacionRequest;
 import com.comerzzia.api.v2.facturacionmagento.web.rest.facturacion.dtos.FacturacionResponse;
 import com.comerzzia.api.v2.facturacionmagento.web.rest.facturacion.dtos.models.DeliveryData;
+import com.comerzzia.api.v2.facturacionmagento.web.rest.facturacion.dtos.models.DocumentOriginData;
 import com.comerzzia.api.v2.facturacionmagento.web.rest.facturacion.dtos.models.Event;
 import com.comerzzia.api.v2.facturacionmagento.web.rest.facturacion.dtos.models.IdentificationCard;
 import com.comerzzia.api.v2.facturacionmagento.web.rest.facturacion.dtos.models.IdentificationCards;
@@ -961,44 +962,125 @@ public class FacturacionService {
 		return cliente;
 	}
 
-	private DatosDocumentoOrigenTicket obtenerDatosTicketOrigen(Long idTratImpuestos) throws FacturacionException {
-		DatosDocumentoOrigenTicket datosTicketOrigen = null;
+        private DatosDocumentoOrigenTicket obtenerDatosTicketOrigen(Long idTratImpuestos) throws FacturacionException {
+                DatosDocumentoOrigenTicket datosTicketOrigen = null;
 
-		try {
-			String uidTicketOrigen = request.getTicket().getTicketHeader().getOriginalTicket();
+                DocumentOriginData documentOriginData = request.getTicket().getTicketHeader().getDocumentOriginData();
+                String uidTicketOrigen = request.getTicket().getTicketHeader().getOriginalTicket();
 
-			if (StringUtils.isNotBlank(uidTicketOrigen)) {
-				log.debug("obtenerDatosTicketOrigen() - Consultando ticket con UID = " + uidTicketOrigen);
-				TicketBean ticketOrigen = ticketService.consultarTicketUid(datosSesion, uidTicketOrigen);
+                if (StringUtils.isNotBlank(uidTicketOrigen)) {
+                        try {
+                                log.debug("obtenerDatosTicketOrigen() - Consultando ticket con UID = " + uidTicketOrigen);
+                                TicketBean ticketOrigen = ticketService.consultarTicketUid(datosSesion, uidTicketOrigen);
 
-				datosTicketOrigen = new DatosDocumentoOrigenTicket();
-				datosTicketOrigen.setCaja(ticketOrigen.getCodCaja());
-				datosTicketOrigen.setCodTicket(ticketOrigen.getCodTicket());
-				datosTicketOrigen.setCodTipoDoc(ticketOrigen.getCodTipoDocumento());
-				datosTicketOrigen.setDesTipoDoc(ticketOrigen.getDesTipoDocumento());
-				datosTicketOrigen.setIdTipoDoc(ticketOrigen.getIdTipoDocumento());
-				datosTicketOrigen.setIdTratImpuestos(idTratImpuestos);
-				datosTicketOrigen.setNumFactura(ticketOrigen.getIdTicket());
-				datosTicketOrigen.setRecoveredOnline(true);
-				datosTicketOrigen.setSerie(ticketOrigen.getSerieTicket());
-				datosTicketOrigen.setUidTicket(ticketOrigen.getUidTicket());
-				Date fechaOrigen = ticketOrigen.getFecha();
-				datosTicketOrigen.setFecha(fechaOrigen);
+                                datosTicketOrigen = new DatosDocumentoOrigenTicket();
+                                datosTicketOrigen.setCaja(ticketOrigen.getCodCaja());
+                                datosTicketOrigen.setCodTicket(ticketOrigen.getCodTicket());
+                                datosTicketOrigen.setCodTipoDoc(ticketOrigen.getCodTipoDocumento());
+                                datosTicketOrigen.setDesTipoDoc(ticketOrigen.getDesTipoDocumento());
+                                datosTicketOrigen.setIdTipoDoc(ticketOrigen.getIdTipoDocumento());
+                                datosTicketOrigen.setIdTratImpuestos(idTratImpuestos);
+                                datosTicketOrigen.setNumFactura(ticketOrigen.getIdTicket());
+                                datosTicketOrigen.setRecoveredOnline(true);
+                                datosTicketOrigen.setSerie(ticketOrigen.getSerieTicket());
+                                datosTicketOrigen.setUidTicket(ticketOrigen.getUidTicket());
+                                Date fechaOrigen = ticketOrigen.getFecha();
+                                datosTicketOrigen.setFecha(fechaOrigen);
 
-				/* Añadimos a la request la fecha origen para que al generar el response más tarde tenga este dato */
-				SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-				String fechaFormateada = dateFormat.format(fechaOrigen);
-				request.getTicket().getTicketIssueData().setOrigenIssueDate(fechaFormateada);
-			}
-		}
-		catch (Exception e) {
-			String msg = "Error consultando ticket origen " + e.getMessage();
-			log.error("obtenerDatosTicketOrigen() - " + msg);
-			throw new FacturacionException(msg, e);
-		}
+                                /* Añadimos a la request la fecha origen para que al generar el response más tarde tenga este dato */
+                                SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+                                String fechaFormateada = dateFormat.format(fechaOrigen);
+                                request.getTicket().getTicketIssueData().setOrigenIssueDate(fechaFormateada);
+                        }
+                        catch (Exception e) {
+                                if (documentOriginData == null) {
+                                        String msg = "Error consultando ticket origen " + e.getMessage();
+                                        log.error("obtenerDatosTicketOrigen() - " + msg);
+                                        throw new FacturacionException(msg, e);
+                                }
 
-		return datosTicketOrigen;
-	}
+                                log.warn("obtenerDatosTicketOrigen() - No se pudo recuperar el ticket origen por UID. Se utilizarán los datos enviados en la petición.", e);
+                        }
+                }
+
+                if (datosTicketOrigen == null && documentOriginData != null) {
+                        datosTicketOrigen = crearDatosTicketOrigenDesdeRequest(documentOriginData, idTratImpuestos);
+                }
+
+                return datosTicketOrigen;
+        }
+
+        private DatosDocumentoOrigenTicket crearDatosTicketOrigenDesdeRequest(DocumentOriginData documentOriginData,
+                        Long idTratImpuestos) throws FacturacionException {
+
+                DatosDocumentoOrigenTicket datosTicketOrigen = new DatosDocumentoOrigenTicket();
+                datosTicketOrigen.setIdTratImpuestos(idTratImpuestos);
+
+                datosTicketOrigen.setSerie(documentOriginData.getSerie());
+                datosTicketOrigen.setCaja(documentOriginData.getCaja());
+                datosTicketOrigen.setCodTicket(documentOriginData.getCodTicket());
+                datosTicketOrigen.setCodTipoDoc(documentOriginData.getCodTipoDocumento());
+                datosTicketOrigen.setDesTipoDoc(documentOriginData.getDesTipoDocumento());
+                datosTicketOrigen.setUidTicket(documentOriginData.getUidTicket());
+
+                if (documentOriginData.getRecoveredOnline() != null) {
+                        datosTicketOrigen.setRecoveredOnline(documentOriginData.getRecoveredOnline());
+                }
+
+                try {
+                        if (StringUtils.isNotBlank(documentOriginData.getNumeroFactura())) {
+                                datosTicketOrigen.setNumFactura(Long.parseLong(documentOriginData.getNumeroFactura()));
+                        }
+
+                        if (StringUtils.isNotBlank(documentOriginData.getIdTipoDocumento())) {
+                                datosTicketOrigen.setIdTipoDoc(Long.parseLong(documentOriginData.getIdTipoDocumento()));
+                        }
+                }
+                catch (NumberFormatException e) {
+                        String msg = "Los datos numéricos del documento origen no tienen el formato correcto";
+                        log.error("crearDatosTicketOrigenDesdeRequest() - " + msg);
+                        throw new FacturacionException(msg, e);
+                }
+
+                Date fechaOrigen = parseFechaDocumentoOrigen(documentOriginData.getFecha());
+                if (fechaOrigen != null) {
+                        datosTicketOrigen.setFecha(fechaOrigen);
+                        actualizarFechaOrigenEnRequest(fechaOrigen);
+                }
+
+                return datosTicketOrigen;
+        }
+
+        private Date parseFechaDocumentoOrigen(String fecha) throws FacturacionException {
+                if (StringUtils.isBlank(fecha)) {
+                        return null;
+                }
+
+                String[] patrones = { "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", "yyyy-MM-dd'T'HH:mm:ssXXX",
+                                "yyyy-MM-dd'T'HH:mm:ss.SSS", "yyyy-MM-dd'T'HH:mm:ss" };
+
+                for (String patron : patrones) {
+                        try {
+                                SimpleDateFormat dateFormat = new SimpleDateFormat(patron);
+                                dateFormat.setLenient(false);
+                                return dateFormat.parse(fecha);
+                        }
+                        catch (ParseException e) {
+                                /* Continuamos probando con el siguiente patrón */
+                        }
+                }
+
+                String msg = "La fecha del documento origen no tiene un formato válido";
+                log.error("parseFechaDocumentoOrigen() - " + msg + ": " + fecha);
+                throw new FacturacionException(msg);
+        }
+
+        private void actualizarFechaOrigenEnRequest(Date fechaOrigen) {
+                if (request.getTicket() != null && request.getTicket().getTicketIssueData() != null) {
+                        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+                        request.getTicket().getTicketIssueData().setOrigenIssueDate(dateFormat.format(fechaOrigen));
+                }
+        }
 
 	private void rellenarLineas(TicketVentaAbono ticketVentaAbono) throws FacturacionException {
 		log.debug("rellenarLineas() - Rellenamos las lineas");

--- a/src/main/java/com/comerzzia/api/v2/facturacionmagento/web/rest/facturacion/dtos/models/DocumentOriginData.java
+++ b/src/main/java/com/comerzzia/api/v2/facturacionmagento/web/rest/facturacion/dtos/models/DocumentOriginData.java
@@ -1,0 +1,99 @@
+package com.comerzzia.api.v2.facturacionmagento.web.rest.facturacion.dtos.models;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DocumentOriginData {
+
+        private String serie;
+        private String caja;
+        private String numeroFactura;
+        private String idTipoDocumento;
+        private String codTipoDocumento;
+        private String desTipoDocumento;
+        private String uidTicket;
+        private String codTicket;
+        private Boolean recoveredOnline;
+        private String fecha;
+
+        public String getSerie() {
+                return serie;
+        }
+
+        public void setSerie(String serie) {
+                this.serie = serie;
+        }
+
+        public String getCaja() {
+                return caja;
+        }
+
+        public void setCaja(String caja) {
+                this.caja = caja;
+        }
+
+        public String getNumeroFactura() {
+                return numeroFactura;
+        }
+
+        public void setNumeroFactura(String numeroFactura) {
+                this.numeroFactura = numeroFactura;
+        }
+
+        public String getIdTipoDocumento() {
+                return idTipoDocumento;
+        }
+
+        public void setIdTipoDocumento(String idTipoDocumento) {
+                this.idTipoDocumento = idTipoDocumento;
+        }
+
+        public String getCodTipoDocumento() {
+                return codTipoDocumento;
+        }
+
+        public void setCodTipoDocumento(String codTipoDocumento) {
+                this.codTipoDocumento = codTipoDocumento;
+        }
+
+        public String getDesTipoDocumento() {
+                return desTipoDocumento;
+        }
+
+        public void setDesTipoDocumento(String desTipoDocumento) {
+                this.desTipoDocumento = desTipoDocumento;
+        }
+
+        public String getUidTicket() {
+                return uidTicket;
+        }
+
+        public void setUidTicket(String uidTicket) {
+                this.uidTicket = uidTicket;
+        }
+
+        public String getCodTicket() {
+                return codTicket;
+        }
+
+        public void setCodTicket(String codTicket) {
+                this.codTicket = codTicket;
+        }
+
+        public Boolean getRecoveredOnline() {
+                return recoveredOnline;
+        }
+
+        public void setRecoveredOnline(Boolean recoveredOnline) {
+                this.recoveredOnline = recoveredOnline;
+        }
+
+        public String getFecha() {
+                return fecha;
+        }
+
+        public void setFecha(String fecha) {
+                this.fecha = fecha;
+        }
+}
+

--- a/src/main/java/com/comerzzia/api/v2/facturacionmagento/web/rest/facturacion/dtos/models/TicketHeader.java
+++ b/src/main/java/com/comerzzia/api/v2/facturacionmagento/web/rest/facturacion/dtos/models/TicketHeader.java
@@ -8,13 +8,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TicketHeader {
 
-	private String origenTicket;
-	private String originalTicket;
-	private String invoiceDocumentType;
-	private String posId;
+        private String origenTicket;
+        private String originalTicket;
+        private String invoiceDocumentType;
+        private String posId;
+        private DocumentOriginData documentOriginData;
 
-	@JsonProperty("audit_events")
-	private AuditEvents auditEvents;
+        @JsonProperty("audit_events")
+        private AuditEvents auditEvents;
 
 	public String getOrigenTicket() {
 		return origenTicket;
@@ -44,15 +45,23 @@ public class TicketHeader {
 		return posId;
 	}
 
-	public void setPosId(String posId) {
-		this.posId = posId;
-	}
+        public void setPosId(String posId) {
+                this.posId = posId;
+        }
 
-	public AuditEvents getAuditEvents() {
-		return auditEvents;
-	}
+        public DocumentOriginData getDocumentOriginData() {
+                return documentOriginData;
+        }
 
-	public void setAuditEvents(AuditEvents auditEvents) {
+        public void setDocumentOriginData(DocumentOriginData documentOriginData) {
+                this.documentOriginData = documentOriginData;
+        }
+
+        public AuditEvents getAuditEvents() {
+                return auditEvents;
+        }
+
+        public void setAuditEvents(AuditEvents auditEvents) {
 		this.auditEvents = auditEvents;
 	}
 


### PR DESCRIPTION
## Summary
- add the `documentOriginData` structure to the ticket header DTO so the API accepts manual origin information
- allow the facturación service to build the original document block either from Comerzzia or from the new payload, parsing dates and numeric fields safely

## Testing
- `mvn -q test` *(fails: parent POM repo is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d51edbd21c832bb50dc6206948add0