### PR TITLE
Add fechaTicketOrigen propagation to generated tickets

### DIFF
--- a/src/main/java/com/comerzzia/api/v2/facturacionmagento/services/facturacion/FacturacionService.java
+++ b/src/main/java/com/comerzzia/api/v2/facturacionmagento/services/facturacion/FacturacionService.java
@@ -724,13 +724,18 @@ public class FacturacionService {
 		ClienteBean datosEnvio = obtenerDatosEnvio();
 		cabecera.setDatosEnvio(datosEnvio);
 
-		DatosDocumentoOrigenTicket datosTicketOrigen = obtenerDatosTicketOrigen(cliente.getIdTratImpuestos());
-		cabecera.setDatosDocOrigen(datosTicketOrigen);
+                DatosDocumentoOrigenTicket datosTicketOrigen = obtenerDatosTicketOrigen(cliente.getIdTratImpuestos());
+                cabecera.setDatosDocOrigen(datosTicketOrigen);
 
-		rellenarTotalesCabecera(cabecera);
-		rellenarImpuestosCabecera(cabecera);
+                TicketIssueData ticketIssueData = request.getTicket() != null ? request.getTicket().getTicketIssueData() : null;
+                if (ticketIssueData != null && StringUtils.isNotBlank(ticketIssueData.getFechaTicketOrigen())) {
+                        cabecera.setFechaTicketOrigen(ticketIssueData.getFechaTicketOrigen());
+                }
 
-		ticketVentaAbono.setCabecera(cabecera);
+                rellenarTotalesCabecera(cabecera);
+                rellenarImpuestosCabecera(cabecera);
+
+                ticketVentaAbono.setCabecera(cabecera);
 	}
 
 	private void setearAuditEvents(BricodepotCabeceraTicket cabecera) throws FacturacionException {
@@ -986,11 +991,17 @@ public class FacturacionService {
 				datosTicketOrigen.setFecha(fechaOrigen);
 
 				/* Añadimos a la request la fecha origen para que al generar el response más tarde tenga este dato */
-				SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-				String fechaFormateada = dateFormat.format(fechaOrigen);
-				request.getTicket().getTicketIssueData().setOrigenIssueDate(fechaFormateada);
-			}
-		}
+                                SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+                                String fechaFormateada = dateFormat.format(fechaOrigen);
+                                request.getTicket().getTicketIssueData().setOrigenIssueDate(fechaFormateada);
+
+                                if (StringUtils.isBlank(request.getTicket().getTicketIssueData().getFechaTicketOrigen())) {
+                                        SimpleDateFormat fechaTicketOrigenFormat = new SimpleDateFormat("dd/MM/yyyy HH:mm");
+                                        request.getTicket().getTicketIssueData()
+                                                        .setFechaTicketOrigen(fechaTicketOrigenFormat.format(fechaOrigen));
+                                }
+                        }
+                }
 		catch (Exception e) {
 			String msg = "Error consultando ticket origen " + e.getMessage();
 			log.error("obtenerDatosTicketOrigen() - " + msg);

--- a/src/main/java/com/comerzzia/api/v2/facturacionmagento/services/ticket/BricodepotCabeceraTicket.java
+++ b/src/main/java/com/comerzzia/api/v2/facturacionmagento/services/ticket/BricodepotCabeceraTicket.java
@@ -21,9 +21,12 @@ import com.comerzzia.omnichannel.model.documents.sales.ticket.cabecera.CabeceraT
 @Scope("prototype")
 public class BricodepotCabeceraTicket extends CabeceraTicket {
 
-	@XmlElementWrapper(name = "eventos_auditoria")
-	@XmlElement(name = "evento")
-	protected List<TicketAuditEvent> auditEvents;
+        @XmlElementWrapper(name = "eventos_auditoria")
+        @XmlElement(name = "evento")
+        protected List<TicketAuditEvent> auditEvents;
+
+        @XmlElement(name = "fechaTicketOrigen")
+        protected String fechaTicketOrigen;
 
 	public BricodepotCabeceraTicket(){
 		auditEvents = new ArrayList<TicketAuditEvent>();
@@ -37,10 +40,18 @@ public class BricodepotCabeceraTicket extends CabeceraTicket {
 		this.auditEvents = auditEvents;
 	}
 
-	public void addAuditEvent(TicketAuditEvent auditEvent) {
-		if (this.auditEvents == null) {
-			this.auditEvents = new ArrayList<>();
-		}
-		this.auditEvents.add(auditEvent);
-	}
+        public void addAuditEvent(TicketAuditEvent auditEvent) {
+                if (this.auditEvents == null) {
+                        this.auditEvents = new ArrayList<>();
+                }
+                this.auditEvents.add(auditEvent);
+        }
+
+        public String getFechaTicketOrigen() {
+                return fechaTicketOrigen;
+        }
+
+        public void setFechaTicketOrigen(String fechaTicketOrigen) {
+                this.fechaTicketOrigen = fechaTicketOrigen;
+        }
 }

--- a/src/main/java/com/comerzzia/api/v2/facturacionmagento/web/rest/facturacion/dtos/models/TicketIssueData.java
+++ b/src/main/java/com/comerzzia/api/v2/facturacionmagento/web/rest/facturacion/dtos/models/TicketIssueData.java
@@ -8,12 +8,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public class TicketIssueData {
 
 	private String invoiceCurrencyCode;
-	private String issueDate;
-	private String origenIssueDate;
-	private TaxesData taxesData;
-	private BigDecimal totalBaseAmount;
-	private BigDecimal totalTaxAmount;
-	private BigDecimal totalGrossAmount;
+        private String issueDate;
+        private String origenIssueDate;
+        private String fechaTicketOrigen;
+        private TaxesData taxesData;
+        private BigDecimal totalBaseAmount;
+        private BigDecimal totalTaxAmount;
+        private BigDecimal totalGrossAmount;
 
 	public String getInvoiceCurrencyCode() {
 		return invoiceCurrencyCode;
@@ -35,13 +36,21 @@ public class TicketIssueData {
 		return origenIssueDate;
 	}
 
-	public void setOrigenIssueDate(String origenIssueDate) {
-		this.origenIssueDate = origenIssueDate;
-	}
+        public void setOrigenIssueDate(String origenIssueDate) {
+                this.origenIssueDate = origenIssueDate;
+        }
 
-	public TaxesData getTaxesData() {
-		return taxesData;
-	}
+        public String getFechaTicketOrigen() {
+                return fechaTicketOrigen;
+        }
+
+        public void setFechaTicketOrigen(String fechaTicketOrigen) {
+                this.fechaTicketOrigen = fechaTicketOrigen;
+        }
+
+        public TaxesData getTaxesData() {
+                return taxesData;
+        }
 
 	public void setTaxesData(TaxesData taxesData) {
 		this.taxesData = taxesData;


### PR DESCRIPTION
## Summary
- allow `TicketIssueData` to persist the `fechaTicketOrigen` value supplied in the request payload
- expose the value in `BricodepotCabeceraTicket` and populate the XML cabecera tag when present
- default the `fechaTicketOrigen` with the original ticket date when it can be derived from the referenced ticket

## Testing
- `mvn -q -DskipTests compile` *(fails: Non-resolvable parent POM for com.comerzzia.bricodepot: blocked mirror for repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68d55778a7d8832babc2ab01e777cbcc